### PR TITLE
Update the conditional in 1.1.5 to be "strictly between"

### DIFF
--- a/src/chapter1/section1/Exercise5.java
+++ b/src/chapter1/section1/Exercise5.java
@@ -8,15 +8,18 @@ import edu.princeton.cs.algs4.StdOut;
 public class Exercise5 {
 
 	public static void main(String[] args) {
-		isBetween0And1(1.12, 1.33);
+		isStrictlyBetween0And1(1.12, 1.33);
         StdOut.println("Expected: false");
 
-		isBetween0And1(0.2, 1);
+		isStrictlyBetween0And1(0.2, 1);
+        StdOut.println("Expected: false");
+
+        isStrictlyBetween0And1(0.5, 0.75);
         StdOut.println("Expected: true");
 	}
 	
-	private static void isBetween0And1(double x, double y) {
-		if (x >= 0 && x <= 1 && y >= 0 && y <= 1 ) {
+	private static void isStrictlyBetween0And1(double x, double y) {
+		if (x > 0 && x < 1 && y > 0 && y < 1 ) {
 			StdOut.println("true");
 		} else {
 			StdOut.println("false");


### PR DESCRIPTION
According to the problem statement, x & y should be "strictly
between" 0 and 1. Per Mathematica (and other sources), that
excludes the boundaries:
http://mathworld.wolfram.com/StrictlyBetween.html

Updated the condition, and also the test cases.