### PR TITLE
Correction of 1.4.5 (g)

### DIFF
--- a/src/chapter1/section4/Exercise5.txt
+++ b/src/chapter1/section4/Exercise5.txt
@@ -6,7 +6,7 @@ c. ~1
 d. ~2N^3
 e. ~1
 f. lg(N^2 + 1) / lg N ~= lg(N^2) / lg N = 2 lg N / lg N = ~2
-g. ~1
+g. ~0
 
 Thanks to mathieu2em (https://github.com/mathieu2em) for correcting this exercise:
 https://github.com/reneargento/algorithms-sedgewick-wayne/issues/32


### PR DESCRIPTION
for g) question, N^100 / 2^N, the answer should be 0.

Reference: 
https://math.stackexchange.com/questions/1455546/lim-limits-n-to-infty-fracn1002n-prove-using-epsilon-definition