### PR TITLE
fix: Exercise10_FasterMerge.java

### DIFF
--- a/src/chapter2/section2/Exercise10_FasterMerge.java
+++ b/src/chapter2/section2/Exercise10_FasterMerge.java
@@ -64,7 +64,7 @@ public class Exercise10_FasterMerge {
         int indexRight = high;
         int arrayIndex = low;
 
-        while (indexLeft <= middle) {
+        while (indexLeft <= indexRight) {
             if (aux[indexLeft].compareTo(aux[indexRight]) <= 0) {
                 array[arrayIndex] = aux[indexLeft];
                 indexLeft++;


### PR DESCRIPTION
I run your code and find it should be **indexRight** but not **middle**, this is a little mistake but confused me some time. I left a comment in [issue#21](https://github.com/reneargento/algorithms-sedgewick-wayne/issues/21) but later I think it's better to open a pull request. Thank you again for your contribution.